### PR TITLE
add wait-for-addrs input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `wait-for-addrs` input that controls whether the action waits for addresses to be assigned to the daemon
 
 ## [1.0.0] - 2021-12-14
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The action starts IPFS daemon and waits for it to become ready.
 | Name | Description | Default |
 | --- | --- | --- |
 | args | Arguments that should be passed to the ipfs daemon command | --init --init-profile server |
+| wait-for-addrs | Whether waits for addresses to be assigned to the daemon | true |
 
 ## Example
 

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: 'Arguments that should be passed to the ipfs daemon command'
     required: false
     default: '--init --init-profile server'
+  wait-for-addrs:
+    description: 'Whether waits for addresses to be assigned to the daemon(defaults to true)'
+    required: false
+    default: true
 runs:
   using: 'composite'
   steps:
@@ -14,4 +18,8 @@ runs:
       shell: bash
     - run: |
         ( ipfs daemon ${{ inputs.args }} & ) | grep -q 'Daemon is ready'
+      shell: bash
+    - if: ${{ inputs.wait-for-addrs == 'true' }}
+      run: |
+        while [[ "$(ipfs id | jq '.Addresses | length')" == '0' ]]; do sleep 1; done
       shell: bash


### PR DESCRIPTION
Implements https://github.com/ipfs/start-ipfs-daemon-action/issues/5

The new input `wait-for-addrs` defaults to `true`. It allows users to opt-out of waiting for addresses to be assigned(e.g. if running the daemon in offline mode).