### PR TITLE
replace grep with sed to log stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `wait-for-addrs` input that controls whether the action waits for addresses to be assigned to the daemon
 
+### Changed
+- ipfs daemon command to log both stdout and stderr
+
 ## [1.0.0] - 2021-12-14
 ### Added
 - action that calls `ipfs daemon` with provided args and waits for `Daemon is ready` on stdout

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ runs:
         sudo sysctl -w net.core.rmem_max=2500000
       shell: bash
     - run: |
-        ( ipfs daemon ${{ inputs.args }} & ) | grep -q 'Daemon is ready'
+        ( ipfs daemon ${{ inputs.args }} & ) | sed '/Daemon is ready/q'
       shell: bash
     - if: ${{ inputs.wait-for-addrs == 'true' }}
       run: |


### PR DESCRIPTION
Implements https://github.com/ipfs/start-ipfs-daemon-action/issues/6

Include the full log output from ipfs daemon command in GitHub Actions logs. It accomplishes this by replacing grep with sed which shows the stdout until the match.